### PR TITLE
Update installation document and script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Want to contribute to this plugin? [More information][3].
 ## Quick Start
 To install the plugin, either:
 
-* clone this repository, then execute `./gradlew run` from the repository's root to start an instance of IntelliJ IDEA with the Spoofax plugin loaded; or
+* clone this repository, then execute `./gradlew runIde` (or `gradlew.bat runIde` on Windows) from the repository's `org.metaborg.intellij` subdirectory to start an instance of IntelliJ IDEA with the Spoofax plugin loaded; or
 * ensure you have Git and a JDK installed, then execute this from the command line; or
 
   ```

--- a/repository/install.sh
+++ b/repository/install.sh
@@ -38,13 +38,13 @@ main() {
 	require_command make
 
 	ensure git clone https://github.com/metaborg/spoofax-intellij.git
-	ensure cd spoofax-intellij
+	ensure cd spoofax-intellij/org.metaborg.intellij
 	ensure ./gradlew install
 
 	say "Ensure you have a JDK installed."
 	say "To start IntelliJ IDEA:"
-	say "  cd spoofax-intellij"
-	say "  ./gradlew run"
+	say "  cd spoofax-intellij/org.metaborg.intellij"
+	say "  ./gradlew runide"
 
 	return 0
 }


### PR DESCRIPTION
Current README and install scripts are outdated and not working. It seems that `gradlew` file was moved inside to the subdirectory from the root directory, and this PR reflects that changes to appropriate files. README description was copied from the [documentation](https://github.com/metaborg/documentation/blob/master/source/langdev/manual/env/intellij/installation.rst).