### PR TITLE
Support multiple name resolution targets

### DIFF
--- a/src/main/java/org/metaborg/intellij/idea/parsing/references/SpoofaxReferenceProvider.java
+++ b/src/main/java/org/metaborg/intellij/idea/parsing/references/SpoofaxReferenceProvider.java
@@ -28,6 +28,7 @@ import org.metaborg.core.language.ILanguageImpl;
 import org.metaborg.core.project.IProject;
 import org.metaborg.core.source.ISourceLocation;
 import org.metaborg.core.tracing.Resolution;
+import org.metaborg.core.tracing.ResolutionTarget;
 import org.metaborg.intellij.idea.languages.ILanguageProjectService;
 import org.metaborg.intellij.idea.projects.IIdeaProjectService;
 import org.metaborg.intellij.resources.IIntelliJResourceService;
@@ -110,7 +111,7 @@ public final class SpoofaxReferenceProvider extends MetaborgReferenceProvider {
     private Iterable<MetaborgReference> getMetaborgReferences(final MetaborgReferenceElement element,
                                                               final Resolution resolution) {
         final List<MetaborgReference> references = new ArrayList<>();
-        for (final Resolution.Target target : resolution.targets) {
+        for (final ResolutionTarget target : resolution.targets) {
             @Nullable final SpoofaxReference reference = getMetaborgReference(element, target.location);
             if (reference != null) {
                 references.add(reference);

--- a/src/main/java/org/metaborg/intellij/idea/parsing/references/SpoofaxReferenceProvider.java
+++ b/src/main/java/org/metaborg/intellij/idea/parsing/references/SpoofaxReferenceProvider.java
@@ -110,8 +110,8 @@ public final class SpoofaxReferenceProvider extends MetaborgReferenceProvider {
     private Iterable<MetaborgReference> getMetaborgReferences(final MetaborgReferenceElement element,
                                                               final Resolution resolution) {
         final List<MetaborgReference> references = new ArrayList<>();
-        for (final ISourceLocation location : resolution.targets) {
-            @Nullable final SpoofaxReference reference = getMetaborgReference(element, location);
+        for (final Resolution.Target target : resolution.targets) {
+            @Nullable final SpoofaxReference reference = getMetaborgReference(element, target.location);
             if (reference != null) {
                 references.add(reference);
             }


### PR DESCRIPTION
Propagates changes to `Resolution`.

PR group:
metaborg/spt#23
metaborg/spoofax#38
metaborg/spoofax-eclipse#13
metaborg/nabl#14
metaborg/spoofax-intellij#29

<img width="240" alt="multi-resolution" src="https://user-images.githubusercontent.com/1237863/42413822-ccb3d196-8228-11e8-9372-b318e9d6fc0c.png">
