### PR TITLE
Apply changes on context and transform APIs

### DIFF
--- a/src/main/java/org/metaborg/intellij/idea/actions/TransformationAction.java
+++ b/src/main/java/org/metaborg/intellij/idea/actions/TransformationAction.java
@@ -131,7 +131,7 @@ public final class TransformationAction extends AnActionWithId {
         final Collection<? extends ISpoofaxTransformUnit<?>> transformResults;
         final IContext context = contextService.get(resource, project, language);
         final ISpoofaxInputUnit input = unitService.inputUnit(resource, text, language, null);
-        if(transformService.requiresAnalysis(context, goal)) {
+        if(transformService.requiresAnalysis(language, goal)) {
             logger.debug("Requesting analysis result.");
             final ISpoofaxAnalyzeUnit result = analysisResultRequester.request(input, context).toBlocking().single();
             logger.debug("Requesting context read lock.");

--- a/src/main/java/org/metaborg/intellij/idea/transformations/ResourceTransformer.java
+++ b/src/main/java/org/metaborg/intellij/idea/transformations/ResourceTransformer.java
@@ -127,7 +127,7 @@ public final class ResourceTransformer<I extends IInputUnit, P extends IParseUni
         final IContext context = this.contextService.get(resource, project, language);
         final I input = unitService.inputUnit(resource, text, language, null);
         final Collection<T> results = Lists.newArrayList();
-        if(this.transformService.requiresAnalysis(context, goal)) {
+        if(this.transformService.requiresAnalysis(language, goal)) {
             for(TA result : transformAnalysis(input, context, goal)) {
                 @SuppressWarnings("unchecked") final T genericResult = (T) result;
                 results.add(genericResult);


### PR DESCRIPTION
Hotfix to the master branch, as apparently the Spoofax build script is currently failing. Worked this out together with @Taeir.

There were two compile errors in this project:

```
/home/maarten/git/spoofax-releng/spoofax-intellij/src/main/java/org/metaborg/intellij/idea/actions/TransformationAction.java:134: error: incompatible types: IContext cannot be converted to ILanguageImpl
        if(transformService.requiresAnalysis(context, goal)) {
                                             ^
/home/maarten/git/spoofax-releng/spoofax-intellij/src/main/java/org/metaborg/intellij/idea/transformations/ResourceTransformer.java:130: error: incompatible types: IContext cannot be converted to ILanguageImpl
        if(this.transformService.requiresAnalysis(context, goal)) {
                                                  ^
```

We found a similar change in the spoofax-eclipse project, namely commit https://github.com/metaborg/spoofax-eclipse/commit/8aad1720982d3930792046def2f2ccf7a7920e5f by @hendrikvanantwerpen.
Passing `language` instead of `context` to the `transformService.requiresAnalysis` method resolves the above compilation error and lets the build script pass again (together with https://github.com/metaborg/jsglr/pull/34).