### PR TITLE
Use our group repository to fix failures due to flaky artifact servers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,21 +36,8 @@ allprojects {
 
     repositories {
         mavenLocal()
-        mavenCentral()
         maven {
-            url "https://artifacts.metaborg.org/content/repositories/releases/"
-        }
-        maven {
-            url "https://artifacts.metaborg.org/content/repositories/snapshots/"
-        }
-        maven {
-            url "https://raw.githubusercontent.com/pluto-build/pluto-build.github.io/master/mvnrepository/"
-        }
-        maven {
-            url "http://sugar-lang.github.io/mvnrepository/"
-        }
-        maven {
-            url "http://nexus.usethesource.io/content/repositories/public/"
+            url "https://artifacts.metaborg.org/content/groups/public/"
         }
     }
 


### PR DESCRIPTION
This uses our group artifact repository, which bundles all the repositories that we host and proxy, which speeds up dependency resolution and fixes failing builds due to flaky artifact servers (mainly http://nexus.usethesource.io/content/repositories/public/).